### PR TITLE
Typo en la dirección de la facultad

### DIFF
--- a/caratula/caratula.sty
+++ b/caratula/caratula.sty
@@ -288,7 +288,7 @@
             \textsf{Universidad de Buenos Aires} \\
             {\scriptsize %
             Ciudad Universitaria - (Pabell\'on I/Planta Baja) \\
-                Intendente G\"uiraldes 2160 - C1428EGA \\
+                Intendente G\"uiraldes 2610 - C1428EGA \\
             Ciudad Aut\'onoma de Buenos Aires - Rep. Argentina \\
                 Tel/Fax: (++54 +11) 4576-3300 \\
             http://www.exactas.uba.ar \\


### PR DESCRIPTION
La dirección que aparece en el sitio de Exactas no existe, está mal tipeada.