### PR TITLE
Use https and remove "www"

### DIFF
--- a/caratula/caratula.sty
+++ b/caratula/caratula.sty
@@ -199,7 +199,7 @@
   \setcounter{page}{1}
 }
 
-% ----- \maketitletxt correspondiente a la versiÛn v0.2.1 (texto v0.2 + fecha ) ---------
+% ----- \maketitletxt correspondiente a la versi√≥n v0.2.1 (texto v0.2 + fecha ) ---------
 
 \def\maketitletxt{%
     \ifsetuperror\errmessage{Faltan datos de la caratula! Ingresar 'h' para mas informacion.}\fi
@@ -248,7 +248,7 @@
     \vspace*{\stretch{4}}
     \newpage\aftermaketitle}
 
-% ----- \maketitlegraf correspondiente a la versiÛn v0.3 (gr·fica) -------------
+% ----- \maketitlegraf correspondiente a la versi√≥n v0.3 (gr√°fica) -------------
 
 \def\maketitlegraf{%
     \ifsetuperror\errmessage{Faltan datos de la caratula! Ingresar 'h' para mas informacion.}\fi
@@ -291,7 +291,7 @@
                 Intendente G\"uiraldes 2610 - C1428EGA \\
             Ciudad Aut\'onoma de Buenos Aires - Rep. Argentina \\
                 Tel/Fax: (++54 +11) 4576-3300 \\
-            http://www.exactas.uba.ar \\
+            https://exactas.uba.ar \\
             }
         \end{minipage}
     \end{minipage}%


### PR DESCRIPTION
El mundo se movió a HTTPS ya, así que usemos https en vez de http.

También saco el "www", pero esto es aun más subjetivo y entiendo si prefieren no cambiarlo :)