### PR TITLE
Actaulizar datos del DC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ La manera más sencilla de usar la carátula:
    - logo_uba.jpg
 2. basarse en los ejemplos
 
+Para tener los logos en una carpeta distinta se puede usar el comando \graphicspath{}. 
+Ej: `\graphicspath{{./imagenes/}}`
+
 ### Ejemplos
 
 - ejemplo_tp_grupal [.tex](caratula/ejemplo_tp_grupal.tex?raw=true) [.lyx](caratula/ejemplo_tp_grupal.lyx?raw=true) [.pdf](caratula/ejemplo_tp_grupal.pdf?raw=true)

--- a/caratula/caratula.sty
+++ b/caratula/caratula.sty
@@ -287,7 +287,7 @@
             \textbf{\textsf{Facultad de Ciencias Exactas y Naturales}} \\
             \textsf{Universidad de Buenos Aires} \\
             {\scriptsize %
-            Ciudad Universitaria - (Pabell\'on Cero\texttt{+}Infinito) \\
+            Ciudad Universitaria - (Pabell\'on Cero \texttt{+} Infinito) \\
                 Intendente G\"uiraldes 2610 - C1428EGA \\
             Ciudad Aut\'onoma de Buenos Aires - Rep. Argentina \\
                 Tel/Conmutador: (+54 11) 5285-9721 / 5285-7400 \\

--- a/caratula/caratula.sty
+++ b/caratula/caratula.sty
@@ -291,7 +291,7 @@
                 Intendente G\"uiraldes 2610 - C1428EGA \\
             Ciudad Aut\'onoma de Buenos Aires - Rep. Argentina \\
                 Tel/Conmutador: (+54 11) 5285-9721 / 5285-7400 \\
-            https://www.dc.uba.ar \\
+            https://dc.uba.ar \\
             }
         \end{minipage}
     \end{minipage}%

--- a/caratula/caratula.sty
+++ b/caratula/caratula.sty
@@ -1,6 +1,6 @@
 % **************************************************************************
 %
-%  Package 'caratula', version 0.5 (para componer caratulas de TPs del DC).
+%  Package 'caratula', version 0.5.1 (para componer caratulas de TPs del DC).
 %
 %  En caso de dudas, problemas o sugerencias sobre este package escribir a
 %  Brian J. Cardiff (bcardif arroba gmail.com).
@@ -11,13 +11,13 @@
 % ----- Informacion sobre el package para el sistema -----------------------
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{caratula}[2013/08/04 v0.5 Para componer caratulas de TPs del DC]
+\ProvidesPackage{caratula}[2023/11/27 v0.5.1 Para componer caratulas de TPs del DC]
 \RequirePackage{ifthen}
 \usepackage[pdftex]{graphicx}
 
 % ----- Imprimir un mensajito al procesar un .tex que use este package -----
 
-\typeout{Cargando package 'caratula' v0.5 (2013/08/04)}
+\typeout{Cargando package 'caratula' v0.5.1 (2023/11/27)}
 
 % ----- Algunas variables --------------------------------------------------
 
@@ -287,11 +287,11 @@
             \textbf{\textsf{Facultad de Ciencias Exactas y Naturales}} \\
             \textsf{Universidad de Buenos Aires} \\
             {\scriptsize %
-            Ciudad Universitaria - (Pabell\'on I/Planta Baja) \\
+            Ciudad Universitaria - (Pabell\'on Cero+Infinito) \\
                 Intendente G\"uiraldes 2610 - C1428EGA \\
             Ciudad Aut\'onoma de Buenos Aires - Rep. Argentina \\
-                Tel/Fax: (++54 +11) 4576-3300 \\
-            https://exactas.uba.ar \\
+                Tel/Conmutador: (+54 11) 5285-9721 / 5285-7400 \\
+            https://www.dc.uba.ar \\
             }
         \end{minipage}
     \end{minipage}%

--- a/caratula/caratula.sty
+++ b/caratula/caratula.sty
@@ -287,7 +287,7 @@
             \textbf{\textsf{Facultad de Ciencias Exactas y Naturales}} \\
             \textsf{Universidad de Buenos Aires} \\
             {\scriptsize %
-            Ciudad Universitaria - (Pabell\'on Cero+Infinito) \\
+            Ciudad Universitaria - (Pabell\'on Cero\texttt{+}Infinito) \\
                 Intendente G\"uiraldes 2610 - C1428EGA \\
             Ciudad Aut\'onoma de Buenos Aires - Rep. Argentina \\
                 Tel/Conmutador: (+54 11) 5285-9721 / 5285-7400 \\


### PR DESCRIPTION
Hola, 

me parece genial que esta caratula la hayas creado en 2005 y la sigamos usando hoy en tantas materias. Si no es molestia, me gustaría subir esta actualización de los datos del DC para luego subir también a cubawiki (que tiene la versión 0.3).

Sume también un comentario en el readme, si no corresponde lo saco.

Adjunto captura de como se ve la parte modifica en pdf.

![imagen](https://github.com/bcardiff/dc-tex/assets/57923445/166930f3-b804-4e0c-b7c8-0d53ace7dfce)

Perdón que son 4 commits, encima no encuentro la opción de squash commits en github, supongo que es algo solo de gitlab.